### PR TITLE
annotation creation endpoint accepts target identifier format.

### DIFF
--- a/src/main/java/com/zenith/livinghistory/api/zenithlivinghistoryapi/controller/AnnotationController.java
+++ b/src/main/java/com/zenith/livinghistory/api/zenithlivinghistoryapi/controller/AnnotationController.java
@@ -27,7 +27,11 @@ public class AnnotationController {
 
     @RequestMapping(method = RequestMethod.POST)
     public ResponseEntity<Annotation> create(@RequestBody @Valid Annotation annotation) {
-        Content content = contentRepository.findOne(annotation.getTarget().getId());
+
+        String[] parts = annotation.getTarget().getId().split("/");
+        String targetId = parts[parts.length-1].split("#")[0];
+
+        Content content = contentRepository.findContentByStoryItemId(targetId);
         List<Annotation> annotations = content.getAnnotations();
         annotations.add(annotation);
         content.setAnnotations(annotations);

--- a/src/main/java/com/zenith/livinghistory/api/zenithlivinghistoryapi/data/repository/ContentRepository.java
+++ b/src/main/java/com/zenith/livinghistory/api/zenithlivinghistoryapi/data/repository/ContentRepository.java
@@ -2,9 +2,12 @@ package com.zenith.livinghistory.api.zenithlivinghistoryapi.data.repository;
 
 import com.zenith.livinghistory.api.zenithlivinghistoryapi.dto.Content;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ContentRepository extends MongoRepository<Content, String> {
 
+    @Query("{story_items:{$elemMatch:{_id: ?0}}}")
+    Content findContentByStoryItemId(String storyItemId);
 }


### PR DESCRIPTION
Annotation creation endpoint accepts target identifier format defined by w3c not mongo object identifier format.